### PR TITLE
fix(addGamesToCollection): bypass consent modal before login

### DIFF
--- a/bgg-bulk-upload.js
+++ b/bgg-bulk-upload.js
@@ -195,6 +195,9 @@ async function addGamesToCollection(arIdsToBeAdded) {
     await driver.get(`${BASE_URL}/login`);
     console.log(RESET, "[Status update] Logging in.");
     await driver.sleep(3000);
+    await driver.executeScript(
+      `document.querySelector("button[class~='fc-cta-consent']").click();`
+    );
     await driver.findElement(By.id("inputUsername")).sendKeys(userName);
     await driver
       .findElement(By.id("inputPassword"))


### PR DESCRIPTION
When launching the import, the password input can not be reached because of the consent modal, which causes the script to crash.
```
 ElementNotInteractableError: element not interactable
  (Session info: chrome=121.0.6167.160)
    at Object.throwDecodedError (/Users/johan.soulet/Projects/bgg-bulk-upload/node_modules/selenium-webdriver/lib/error.js:524:15)
    at parseHttpResponse (/Users/johan.soulet/Projects/bgg-bulk-upload/node_modules/selenium-webdriver/lib/http.js:587:13)
    at Executor.execute (/Users/johan.soulet/Projects/bgg-bulk-upload/node_modules/selenium-webdriver/lib/http.js:515:28)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async thenableWebDriverProxy.execute (/Users/johan.soulet/Projects/bgg-bulk-upload/node_modules/selenium-webdriver/lib/webdriver.js:745:17)
    at async addGamesToCollection (/Users/johan.soulet/Projects/bgg-bulk-upload/bgg-bulk-upload.js:201:5)
```

This line closes the modal before entering the credentials so the script can go on.